### PR TITLE
build: update deps and remove pre-release tag by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,5 @@ jobs:
         with:
           go-version: 1.21
       - uses: go-semantic-release/action@v1
-        with:
-          prerelease: true
-#          hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-openapi/runtime v0.25.0
 	github.com/golang/glog v1.1.2
 	github.com/netbox-community/go-netbox/v3 v3.4.5
-	github.com/scottlaird/netboxlib v0.0.0-20231015160834-2f320eeb914f
+	github.com/scottlaird/netboxlib v1.0.0
 	github.com/shuLhan/share v0.43.0
 	google.golang.org/api v0.154.0
 )

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.11.1-0.20231026093722-fa6a31e0812c h1:fPpdjePK1atuOg28PXfNSqgwf9I/qD1Hlo39JFwKBXk=
-github.com/scottlaird/netboxlib v0.0.0-20231015160834-2f320eeb914f h1:U/6ZYtWVmVgQ4E6UCO3YL0owFNpBjNkmD0UiiedhaHs=
-github.com/scottlaird/netboxlib v0.0.0-20231015160834-2f320eeb914f/go.mod h1:7Xwa7EHtoNBEI9Efu5fAa1mWh+naPE6njJvdhurR6Yk=
+github.com/scottlaird/netboxlib v1.0.0 h1:t9kxciDgvVh5FHcQWc1RGonIk4esvOQt4mZONnxutKc=
+github.com/scottlaird/netboxlib v1.0.0/go.mod h1:7Xwa7EHtoNBEI9Efu5fAa1mWh+naPE6njJvdhurR6Yk=
 github.com/shuLhan/share v0.43.0 h1:WEaMg7WIX6YAvDphQjbPSZqz/ubuotRtD7Fq4zGO8Wc=
 github.com/shuLhan/share v0.43.0/go.mod h1:nus6RSASS+5P1ZUe89ciJZyp3v+IY1xqLdKwtnuGsaA=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
Now using v1.0.0 of my netbox library.